### PR TITLE
Support eu region

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ const logger = winston.createLogger({
   transports: [
     new DatadogTransport({
       apiKey: process.env.DD_API_KEY, // Datadog API key
+      port: 443, // optional port, 443 is for EU region secure port
+      host: 'tcp-intake.logs.datadoghq.eu', // optinal host, 'tcp-intake.logs.datadoghq.eu' is for EU region host
       // optional metadata which will be merged with every log message
       metadata: {
         ddsource: 'lambda',

--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ module.exports = class DatadogTransport extends Transport {
 
     this.metadata = {};
     config.apiKey = opts.apiKey;
+    // add port and host as optional options
+    //so the user can change the port and host when his Databog region is not US
+    config.port = opts.port || config.port;
+    config.host = opts.host || config.host;
+
 
     if (opts.metadata) {
       Object.assign(this.metadata, opts.metadata);


### PR DESCRIPTION
This package is great, but it doesn't support the Datadog **EU** region because the port and host are fixed in the configuration and only pointing to **US** region.

So, I have added **_port_** and **_host_** to the constructor parameters as an optional params so that the user can pass them when creating new instance form **DatadogTransport** class.

this modifications will allow this package to support the current datadog regions and any region that may be added in the future.
-----------------------
From [Datadog documentation](https://docs.datadoghq.com/logs/log_collection/?tab=tcp):

> EU host: tcp-intake.logs.datadoghq.eu

> EU secure TCP port: 443

> US host: intake.logs.datadoghq.com

> US secure TCP port: 10516

